### PR TITLE
docs: Removed AWS credits references in existing content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.hugo_build.lock

--- a/content/030_self_guided_setup/30_aws_setup_your_own.md
+++ b/content/030_self_guided_setup/30_aws_setup_your_own.md
@@ -9,7 +9,7 @@ weight: 10
 {{% children %}}
 
 {{% notice warning %}}
-You are responsible for the cost of the AWS services used while running this workshop in your AWS account. We highly recommend you to go to the [request AWS credit page](/030_self_guided_setup/32_request_credit.html) so you can run this workshop without any charge to you.
+You are responsible for the cost of the AWS services used while running this workshop in your AWS account.
 {{% /notice %}}
 
 1. If you don't already have an AWS account with Administrator access: [create one now by clicking here](https://aws.amazon.com/getting-started/)

--- a/content/030_self_guided_setup/_index.md
+++ b/content/030_self_guided_setup/_index.md
@@ -7,7 +7,7 @@ weight: 3
 
 # Self-Paced Workshop
 
-Welcome to the Self Guided Setup section! This workshop requires an AWS account where there is IAM user/identity that has proper permissions to set up the necessary AWS components to work through the workshop. Worried about costs associated with this workshop? Don't worry, there's a page that will allow you to request for AWS credits to pay for any costs incurred through this workshop!
+Welcome to the Self Guided Setup section! This workshop requires an AWS account where there is IAM user/identity that has proper permissions to set up the necessary AWS components to work through the workshop.
 
 Here is a preview of what we will be setting up:
 

--- a/content/090_cleanup/_index.md
+++ b/content/090_cleanup/_index.md
@@ -7,4 +7,4 @@ weight: 90
 
 # Workshop Cleanup
 
-Congratulations on completing the workshop! Now although you may AWS credits to pay for the costs incurred today, the next few sections will instruct you how to turn off all the infrastructure you’ve created in order to work through the material.
+Congratulations on completing the workshop! The next few sections will instruct you how to turn off all the infrastructure you’ve created in order to work through the material.


### PR DESCRIPTION
*Issue #9 *

Resolves #9 

*Description of changes:*
- Removes the remaining references of AWS credits in the workshop content.
- If these are not to be remove, the PR can be closed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
